### PR TITLE
Update README.md to use 3.12 Python instead of 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This system provides **secure, granular access control** for AI agents interacti
 
 ### **Prerequisites**
 ```bash
-# Python 3.11+ required
+# Python 3.12+ required
 python --version
 
 # Install dependencies


### PR DESCRIPTION
without the right Python version we might run into an issue when running the `pip install -r requirements.txt` command to install the needed dependencies.

```
ERROR: Ignored the following versions that require a different python version: 0.2.13 Requires-Python >=3.12; 0.2.14 Requires-Python >=3.12
ERROR: Could not find a version that satisfies the requirement llama_stack_client==0.2.13 (from versions: 0.0.1a0, 0.0.2a0, 0.0.3a0, 0.0.3a1, 0.0.3a2, 0.0.4a0, 0.0.5a0, 0.0.25, 0.0.35, 0.0.39, 0.0.40, 0.0.41, 0.0.47, 0.0.48a1, 0.0.48, 0.0.49, 0.0.50, 0.0.53, 0.0.54, 0.0.55, 0.0.56, 0.0.57, 0.0.58, 0.0.59, 0.0.60, 0.0.61, 0.0.62, 0.0.63, 0.1.0, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.1.7, 0.1.8, 0.1.9, 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.5, 0.2.6, 0.2.7, 0.2.8, 0.2.9, 0.2.10, 0.2.11, 0.2.12)
ERROR: No matching distribution found for llama_stack_client==0.2.13
```