### PR TITLE
PoC of kubernetes-mcp-server integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # 🔐 Authentication & Authorization System for AI Agents
 
-A comprehensive authentication and authorization system for AI agents with **Google OAuth**, **JWT tokens**, **scope-based permissions**, and **real-time approval workflows**. Built for secure MCP (Model Context Protocol) tool access with automatic permission escalation.
+A comprehensive authentication and authorization system for AI agents with **OIDC**, **JWT tokens**, **scope-based permissions**, and **real-time approval workflows**. Built for secure MCP (Model Context Protocol) tool access with automatic permission escalation.
 
 ## 🎯 **What This System Does**
 
-This system provides **secure, granular access control** for AI agents interacting with system resources. Users authenticate once via Google OAuth, then the system automatically manages permissions as AI agents request access to different tools and resources.
+This system provides **secure, granular access control** for AI agents interacting with system resources. Users authenticate once via OIDC, then the system automatically manages permissions as AI agents request access to different tools and resources.
 
 ### **Key Capabilities**
-- 🔐 **Google OAuth Authentication** - Secure login with Google accounts
+- 🔐 **OIDC Authentication** - Secure login using OIDC
 - 🎫 **JWT Token Management** - Automatic token generation and refresh
 - 🔧 **MCP Tool Integration** - Secure access to file system, commands, and APIs
 - 📋 **Dynamic Approval Workflows** - Auto-approve safe operations, require admin approval for risky ones
@@ -58,7 +58,7 @@ cp env.example .env
 # Edit .env file with your settings:
 # - ADMIN_EMAIL (required)
 # - OPENAI_API_KEY (required for AI agents)
-# - GOOGLE_CLIENT_ID/SECRET (required for Google OAuth)
+# - OIDC_CLIENT_ID/SECRET (required for OIDC)
 ```
 
 ### **Start the System**
@@ -83,11 +83,95 @@ cp env.example .env
 
 ⚠️ **Important**: `stop_demo.sh` will **force close Chrome** to clear authentication cookies. Save any important Chrome work before running this command.
 
-## 🔐 **Google OAuth Setup**
+## OIDC Provider
+
+Before running the demo, you need to set up an OIDC Provider (such as Keycloak or Google).
+
+### 🔐 **Keycloak**
+
+Before running the demo, you can use Keycloak as a OIDC provider. Follow these steps:
+
+#### **1. Create a new Realm**
+
+_Note_: This step is not required, but highly encouraged
+
+1. **Go to the Keycloak Administration Interface**
+2. **Click Manage Realms**
+3. **Click Create realm** or select an existing one
+  - Enter the name of the desired realm
+  - Click "Create"
+
+#### **2. Create Users**
+
+There must be at least one user created in the realm. Use the following steps to create a user and assign a password:
+
+1. **Ensure you are in the desired realm**
+2. **Click Users on the left hand navigation**
+3. **Click Add User**
+4. **Enter the following in the Create User page**
+  - Username
+  - Email
+  - First Name
+  - Last Name
+  - Email Verified (checked)
+  - Click "Create"
+5. **Set a password for the user**
+  - Click the "Credentials" tab
+  - Click "Set password"
+  - Enter and confirm the desired password
+  - Deselect "Temporary"
+  - Click "Save"
+
+#### **3. Create an OIDC Client**
+
+1. **Ensure you are in the desired realm**
+2. **Click Clients on the left hand navigation**
+3. **Click Create client**
+4. **Fill out the General Settings section**
+  - Client ID (such as `authentication-demo`)
+  - Click "Next"
+5. **Fill out the Capability Config section**
+  - Enable "Client Authentication"
+  - Click "Next"
+6. **Fill out the Login Settings section**
+   - Valid redirect URI's:
+     ```
+     http://localhost:8002/auth/callback
+     http://localhost:5001/callback
+     http://localhost:8003/callback
+     ```
+   - Click "Save"
+7. ***Obtain Client Secret**
+  - Click on "Credentials" tab
+  - Reveal or copy the secret next to "Client Secret"
+
+#### **4. Obtain OIDC Issuer URL**
+
+1. **Ensure you are in the desired realm**
+2. **Click Realm Settings on the left hand navigation**
+3. **Click the `OpenID Endpoint Configuration` link**
+4. **The OIDC Issuer can be found within the `issuer` property**
+
+#### **5. Update Environment Variables**
+
+Add your Keycloak OAuth credentials to your `.env` file:
+
+```bash
+# Required Keycloak OAuth credentials
+OIDC_ISSUER_URL="your-realm-oidc-issuer"
+OIDC_CLIENT_ID="your-client-id-here"
+OIDC_CLIENT_SECRET="your-client-secret-here"
+
+# Other required variables
+ADMIN_EMAIL="your-admin@example.com"
+OPENAI_API_KEY="your-openai-api-key"
+```
+
+### 🔐 **Google OAuth Setup**
 
 Before running the demo, you need to set up Google OAuth credentials. Follow these steps:
 
-### **1. Create Google Cloud Project**
+#### **1. Create Google Cloud Project**
 
 1. **Go to Google Cloud Console**: https://console.cloud.google.com/
 2. **Create a new project** or select an existing one
@@ -96,7 +180,7 @@ Before running the demo, you need to set up Google OAuth credentials. Follow the
    - Search for "Google+ API" 
    - Click "Enable"
 
-### **2. Configure OAuth Consent Screen**
+#### **2. Configure OAuth Consent Screen**
 
 1. **Go to "APIs & Services" > "OAuth consent screen"**
 2. **Choose "External" user type** (unless you have a Google Workspace)
@@ -134,14 +218,15 @@ Before running the demo, you need to set up Google OAuth credentials. Follow the
 5. **Click "Create"**
 6. **Copy the Client ID and Client Secret** - you'll need these for your `.env` file
 
-### **4. Update Environment Variables**
+#### **4. Update Environment Variables**
 
 Add your Google OAuth credentials to your `.env` file:
 
 ```bash
 # Required Google OAuth credentials
-GOOGLE_CLIENT_ID="your-client-id-here.apps.googleusercontent.com"
-GOOGLE_CLIENT_SECRET="your-client-secret-here"
+OIDC_ISSUER_URL=https://accounts.google.com
+OIDC_CLIENT_ID="your-client-id-here.apps.googleusercontent.com"
+OIDC_CLIENT_SECRET="your-client-secret-here"
 
 # Other required variables
 ADMIN_EMAIL="your-admin@example.com"
@@ -152,7 +237,7 @@ OPENAI_API_KEY="your-openai-api-key"
 
 1. **Start the demo**: `./start_demo.sh`
 2. **Visit**: http://localhost:5001
-3. **Click login** - you should be redirected to Google
+3. **Click login** - you should be redirected to th configured OIDC provider
 4. **Sign in** with a test user email you added
 5. **Grant permissions** to the app
 6. **You should be redirected back** to the chat interface
@@ -190,7 +275,7 @@ The following diagram shows the streamlined OAuth authentication and MCP token d
 ### **How It Works**
 
 1. **🔐 Initial Authentication**
-   - User accesses Chat UI → redirected to Google OAuth
+   - User accesses Chat UI → redirected to OIDC provider
    - After OAuth success → user gets Llama Stack session token
    - Session token enables basic chat functionality
 
@@ -213,7 +298,7 @@ The following diagram shows the streamlined OAuth authentication and MCP token d
 
 ### **1. First-Time User Experience**
 1. **Access** http://localhost:5001
-2. **Login** with Google OAuth
+2. **Login** to the configured OIDC provider
 3. **Start with no permissions** - secure by default
 4. **Try a command**: "List files in /tmp"
 5. **See auto-approval** for safe operations
@@ -221,7 +306,7 @@ The following diagram shows the streamlined OAuth authentication and MCP token d
 
 ### **2. Admin Approval Workflow**
 1. **Try risky command**: "Execute command: ls -la"
-2. **See approval request** created automatically
+2. **See approvalf request** created automatically
 3. **Admin reviews** in dashboard at http://localhost:8003/dashboard
 4. **Approve/deny** with justification
 5. **User gets notification** and can retry
@@ -239,8 +324,9 @@ The following diagram shows the streamlined OAuth authentication and MCP token d
 # Required
 ADMIN_EMAIL="your-admin@example.com"
 OPENAI_API_KEY="your-openai-api-key"
-GOOGLE_CLIENT_ID="your-google-client-id"
-GOOGLE_CLIENT_SECRET="your-google-client-secret"
+OIDC_ISSUER_URL="your-oidc-issuer-url"
+OIDC_CLIENT_ID="your-oidc-client-id"
+OIDC_CLIENT_SECRET="your-oidc-client-secret"
 
 # Advanced
 JWT_MODE="asymmetric"  # or "symmetric"
@@ -398,10 +484,10 @@ tail -f logs/auth-server.log
 # (Use links in chat UI token dashboard)
 ```
 
-**Google OAuth setup required:**
+**OIDC setup required:**
 ```bash
-# Check Google OAuth credentials in .env
-cat .env | grep GOOGLE_
+# Check OIDC credentials in .env
+cat .env | grep OIDC_
 
 # Verify auth server is running
 curl http://localhost:8002/health

--- a/auth-server/api/auth_routes.py
+++ b/auth-server/api/auth_routes.py
@@ -75,13 +75,13 @@ async def oauth_callback(code: str, state: str):
                 logger.error(f"❌ Failed to decode OAuth request: {e}")
         
         # Get Google's token endpoint from discovery document
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             discovery_response = await client.get(OIDC_DISCOVERY_URL)
             discovery_data = discovery_response.json()
             token_endpoint = discovery_data["token_endpoint"]
         
         # Exchange code for token (simplified)
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             token_response = await client.post(
                 token_endpoint,
                 data={

--- a/auth-server/auth/oauth_utils.py
+++ b/auth-server/auth/oauth_utils.py
@@ -21,7 +21,7 @@ async def load_oidc_config():
     global oidc_config
     
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             response = await client.get(OIDC_DISCOVERY_URL)
             if response.status_code == 200:
                 config_data = response.json()
@@ -64,7 +64,7 @@ async def exchange_code_for_token(code: str) -> dict:
         'redirect_uri': REDIRECT_URI
     }
     
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=False) as client:
         response = await client.post(
             oidc_config.token_endpoint,
             data=token_data,
@@ -82,7 +82,7 @@ async def get_user_info(access_token: str) -> dict:
     if not oidc_config:
         raise ValueError("OIDC configuration not loaded")
     
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=False) as client:
         response = await client.get(
             oidc_config.userinfo_endpoint,
             headers={'Authorization': f'Bearer {access_token}'}

--- a/auth-server/config/settings.py
+++ b/auth-server/config/settings.py
@@ -3,6 +3,7 @@ Configuration settings for the auth server
 """
 
 import os
+from urllib.parse import urljoin
 
 # Server Configuration
 SERVER_NAME = "unified-auth-server"
@@ -11,11 +12,11 @@ SERVER_HOST = os.getenv("SERVER_HOST", "localhost")
 SERVER_PORT = int(os.getenv("SERVER_PORT", "8002"))
 SERVER_URI = f"http://{SERVER_HOST}:{SERVER_PORT}"
 
-# Google OAuth 2.0 Configuration
-GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "your-google-client-id")
-GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET", "your-google-client-secret")
-GOOGLE_DISCOVERY_URL = "https://accounts.google.com/.well-known/openid-configuration"
-GOOGLE_ISSUER = "https://accounts.google.com"
+# OIDC Configuration
+OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID", "your-oidc-client-id")
+OIDC_CLIENT_SECRET = os.getenv("OIDC_CLIENT_SECRET", "your-oidc-client-secret")
+OIDC_ISSUER_URL = os.getenv("OIDC_ISSUER_URL", "your-oidc-issuer-url")
+OIDC_DISCOVERY_URL = f"{OIDC_ISSUER_URL}/.well-known/openid-configuration"
 REDIRECT_URI = f"{SERVER_URI}/auth/callback"
 
 # Session management

--- a/auth-server/main.py
+++ b/auth-server/main.py
@@ -19,7 +19,7 @@ from config.settings import SERVER_NAME, SERVER_VERSION, SERVER_HOST, SERVER_POR
 
 # Import utilities
 from utils import jwt_utils
-from auth.oauth_utils import load_google_config
+from auth.oauth_utils import load_oidc_config
 from database import auth_db
 
 # Import route modules
@@ -74,10 +74,10 @@ async def startup_event():
         logger.error("❌ Failed to load JWT keys")
         sys.exit(1)
     
-    # Load Google OAuth configuration
-    logger.info("🔐 Loading Google OAuth configuration...")
-    if not await load_google_config():
-        logger.error("❌ Failed to load Google OAuth configuration")
+    # Load OIDC configuration
+    logger.info("🔐 Loading OIDC configuration...")
+    if not await load_oidc_config():
+        logger.error("❌ Failed to load OIDC configuration")
         sys.exit(1)
     
     # Initialize admin user if configured
@@ -114,7 +114,7 @@ async def startup_event():
                 logger.info("")
                 logger.info("📋 Next Steps:")
                 logger.info("1. Visit the login URL above")
-                logger.info(f"2. Sign in with Google using: {admin_email}")
+                logger.info(f"2. Sign in with OIDC using: {admin_email}")
                 logger.info("3. Access the admin dashboard to manage permissions")
                 logger.info("=" * 60)
             else:

--- a/auth-server/models/schemas.py
+++ b/auth-server/models/schemas.py
@@ -59,7 +59,7 @@ class ProtectedResourceMetadata(BaseModel):
     bearer_methods_supported: Optional[List[str]] = None
     resource_documentation: Optional[str] = None
 
-class GoogleDiscoveryDocument(BaseModel):
+class OIDCDiscoveryDocument(BaseModel):
     issuer: str
     authorization_endpoint: str
     token_endpoint: str

--- a/env.example
+++ b/env.example
@@ -1,9 +1,8 @@
-# Google OAuth 2.0 Configuration
-# Get these from Google Cloud Console: https://console.cloud.google.com/
 # Create a new OAuth 2.0 Client ID or use an existing one
 
-GOOGLE_CLIENT_ID=your_google_client_id_here
-GOOGLE_CLIENT_SECRET=your_google_client_secret_here
+OIDC_ISSUER_URL=your_oidc_issuer_url
+OIDC_CLIENT_ID=your_oidc_client_id_here
+OIDC_CLIENT_SECRET=your_oidc_client_secret_here
 
 # OpenAI API Configuration
 # Required for GPT-4 model in Llama Stack (frontend/stack/run.yml)

--- a/frontends/chat-ui/api/auth.py
+++ b/frontends/chat-ui/api/auth.py
@@ -100,7 +100,7 @@ def handle_oauth_callback():
 async def exchange_code_for_token(code: str) -> dict:
     """Exchange authorization code for access token"""
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             # Exchange code for token with auth server
             response = await client.post(
                 f"{AUTH_SERVER_URL}/oauth/token",
@@ -153,7 +153,7 @@ async def exchange_code_for_token(code: str) -> dict:
 async def get_user_info(access_token: str) -> dict:
     """Get user info from OIDC"""
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             response = await client.get(OIDC_DISCOVERY_URL)
 
             if response.status_code == 200:
@@ -167,7 +167,7 @@ async def get_user_info(access_token: str) -> dict:
                 logger.error(f"❌ Error getting OIDC Discovery Document")
                 return None
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             response = await client.get(
                 userinfo_endpoint,
                 headers={'Authorization': f'Bearer {access_token}'},
@@ -187,7 +187,7 @@ async def get_user_info(access_token: str) -> dict:
 async def get_bearer_token_from_auth_server(user_info: dict) -> str:
     """Get bearer token from auth server"""
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             response = await client.post(
                 f"{AUTH_SERVER_URL}/api/get-token",
                 json=user_info,

--- a/frontends/chat-ui/api/chat.py
+++ b/frontends/chat-ui/api/chat.py
@@ -441,7 +441,7 @@ def handle_consent_response():
             import asyncio
             
             async def update_consent_response():
-                async with httpx.AsyncClient() as client:
+                async with httpx.AsyncClient(verify=False) as client:
                     response = await client.put(
                         f'{AUTH_SERVER_URL}/api/consent-requests/{consent_id}',
                         json={

--- a/frontends/chat-ui/api/tokens.py
+++ b/frontends/chat-ui/api/tokens.py
@@ -528,7 +528,7 @@ def update_mcp_token_cookie():
         
         # For now, skip setting cookies to avoid cookie size issues with multiple MCP servers
         # Cookies are not essential for MCP token functionality - tokens are stored in session/database
-        base_server_url = server_url.rstrip('/sse') if server_url.endswith('/sse') else server_url
+        base_server_url = server_url.rstrip('/mcp') if server_url.endswith('/mcp') else server_url
         
         # Skip cookie setting since we now support multiple dynamically discovered MCP servers
         # and cookies have size limitations

--- a/frontends/chat-ui/api/tokens.py
+++ b/frontends/chat-ui/api/tokens.py
@@ -131,7 +131,8 @@ def check_token_update():
                 response = requests.get(
                     f"{auth_server_url}/api/check-token-update",
                     cookies=auth_cookies,
-                    timeout=10
+                    timeout=10,
+                    verify=False
                 )
                 
                 if response.status_code == 200:
@@ -299,7 +300,8 @@ def refresh_llama_stack_token():
         user_status_response = requests.get(
             f"{AUTH_SERVER_URL}/api/user-status",
             cookies=auth_cookies,
-            timeout=10
+            timeout=10,
+            verify=False
         )
         
         if user_status_response.status_code != 200:
@@ -325,7 +327,8 @@ def refresh_llama_stack_token():
                 "scopes": llama_stack_scopes  # Use filtered scopes
             },
             cookies=auth_cookies,
-            timeout=10
+            timeout=10,
+            verify=False
         )
         
         if token_response.status_code == 200:

--- a/frontends/chat-ui/app.py
+++ b/frontends/chat-ui/app.py
@@ -470,7 +470,7 @@ def health():
 
 def get_base_mcp_url(mcp_server_url: str) -> str:
     """Get base MCP URL by stripping /sse suffix if present"""
-    if mcp_server_url.endswith('/sse'):
+    if mcp_server_url.endswith('/mcp'):
         return mcp_server_url[:-4]
     return mcp_server_url
 

--- a/frontends/chat-ui/app.py
+++ b/frontends/chat-ui/app.py
@@ -77,7 +77,7 @@ def check_auth_server_session():
             return None
         
         # Verify session with auth server
-        with httpx.Client() as client:
+        with httpx.Client(verify=False) as client:
             response = client.get(
                 f"{AUTH_SERVER_URL}/api/user-status", 
                 cookies={'auth_session': auth_session_cookie},
@@ -104,7 +104,7 @@ async def request_llama_stack_token(auth_cookies: dict = {}, auth_server_url: st
             auth_server_url = AUTH_SERVER_URL
             logger.info(f"🔍 Using default auth server for Llama Stack: {auth_server_url}")
         
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             response = await client.post(
                 f"{auth_server_url}/api/initial-token",
                 json={
@@ -139,7 +139,7 @@ def index():
         try:
             # Verify session with auth server
             import httpx
-            with httpx.Client() as client:
+            with httpx.Client(verify=False) as client:
                 response = client.get(
                     f"{AUTH_SERVER_URL}/api/user-status", 
                     cookies={'auth_session': auth_session_cookie},
@@ -210,7 +210,7 @@ def callback():
     try:
         # Exchange code for tokens via auth server
         import httpx
-        with httpx.Client() as client:
+        with httpx.Client(verify=False) as client:
             # First, complete OAuth flow with auth server
             response = client.post(
                 f"{AUTH_SERVER_URL}/auth/token",
@@ -301,6 +301,7 @@ def callback():
                                         
                                         # Strip /sse suffix to get base URL for service discovery
                                         base_mcp_url = mcp_url.rstrip('/sse')
+                                        base_mcp_url = mcp_url.rstrip('/mcp')
                                         
                                         mcp_server_urls.append(base_mcp_url)
                                         logger.info(f"✅ Found MCP server: {base_mcp_url} (endpoint: {mcp_url})")

--- a/frontends/chat-ui/app.py
+++ b/frontends/chat-ui/app.py
@@ -42,8 +42,8 @@ app.config.update(
 )
 
 # Configuration - these will be moved to config files later
-GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
-GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
+OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID")
+OIDC_CLIENT_SECRET = os.getenv("OIDC_CLIENT_SECRET")
 AUTH_SERVER_URL = os.getenv("AUTH_SERVER_URL", "http://localhost:8002")
 LLAMA_STACK_URL = os.getenv("LLAMA_STACK_URL", "http://localhost:8321")
 REDIRECT_URI = os.getenv("REDIRECT_URI", "http://localhost:5001/callback")

--- a/frontends/chat-ui/templates/login.html
+++ b/frontends/chat-ui/templates/login.html
@@ -76,15 +76,15 @@
         <p class="subtitle">Secure chat with AI agents and MCP tools</p>
         
         <a href="/login" class="login-btn">
-            🔐 Login with Google
+            🔐 OIDC Login
         </a>
         
         <p style="margin-top: 20px; font-size: 12px; color: #999;">
-            Secure authentication via Google OAuth
+            Secure authentication via OIDC
         </p>
         
         <div class="features">
-            <div class="feature">Google OAuth authentication</div>
+            <div class="feature">OIDC authentication</div>
             <div class="feature">Llama Stack agents with MCP tools</div>
             <div class="feature">Secure Bearer token authentication</div>
             <div class="feature">Real-time chat interface</div>

--- a/frontends/chat-ui/utils/auth_utils.py
+++ b/frontends/chat-ui/utils/auth_utils.py
@@ -26,7 +26,7 @@ def check_auth_server_session_direct():
             return None
         
         # Verify session with auth server
-        with httpx.Client() as client:
+        with httpx.Client(verify=False) as client:
             response = client.get(
                 f"{AUTH_SERVER_URL}/api/user-status", 
                 cookies={'auth_session': auth_session_cookie},

--- a/frontends/chat-ui/utils/mcp_tokens_utils.py
+++ b/frontends/chat-ui/utils/mcp_tokens_utils.py
@@ -170,7 +170,7 @@ async def request_scope_upgrade(required_scope: str, user_token: str, auth_cooki
             upgrade_data["current_token"] = current_token
             logger.info(f"🔄 Including current MCP token for scope upgrade: {current_token[:20]}...")
         
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             response = await client.post(
                 f"{auth_server_url}/api/upgrade-scope",
                 json=upgrade_data,
@@ -244,7 +244,7 @@ async def request_mcp_token(required_scope: str, mcp_server_url: str, current_to
         # Get base URL for consistent token storage
         base_mcp_url = get_base_mcp_url(mcp_server_url)
         
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(verify=False) as client:
             # Use the dedicated MCP token endpoint
             response = await client.post(
                 f"{auth_server_url}/api/request-mcp-token",

--- a/frontends/chat-ui/utils/mcp_tokens_utils.py
+++ b/frontends/chat-ui/utils/mcp_tokens_utils.py
@@ -20,7 +20,7 @@ AUTH_SERVER_URL = "http://localhost:8002"  # Default fallback
 
 def get_base_mcp_url(mcp_server_url: str) -> str:
     """Get base MCP URL by stripping /sse suffix if present"""
-    if mcp_server_url.endswith('/sse'):
+    if mcp_server_url.endswith('/mcp'):
         return mcp_server_url[:-4]
     return mcp_server_url
 
@@ -117,8 +117,8 @@ def prepare_mcp_headers_for_user(user_email: str) -> dict:
             if mcp_token and mcp_token != "NO_TOKEN_YET":
                 # Convert base URL to SSE endpoint URL for Llama Stack
                 mcp_endpoint_url = mcp_server_url
-                if not mcp_endpoint_url.endswith('/sse'):
-                    mcp_endpoint_url = f"{mcp_server_url}/sse"
+                if not mcp_endpoint_url.endswith('/mcp'):
+                    mcp_endpoint_url = f"{mcp_server_url}/mcp"
                 
                 mcp_headers[mcp_endpoint_url] = {
                     "Authorization": f"Bearer {mcp_token}"

--- a/frontends/chat-ui/utils/service_discovery.py
+++ b/frontends/chat-ui/utils/service_discovery.py
@@ -34,7 +34,7 @@ class MCPServiceDiscovery:
             discovery_url = urljoin(mcp_server_url, "/.well-known/oauth-protected-resource")
             logger.info(f"🔍 Discovering MCP auth config: {discovery_url}")
             
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(verify=False) as client:
                 response = await client.get(discovery_url, timeout=self.timeout)
                 
                 if response.status_code == 200:

--- a/frontends/chat-ui/utils/streaming_utils.py
+++ b/frontends/chat-ui/utils/streaming_utils.py
@@ -264,7 +264,7 @@ def stream_agent_response_with_auth_detection(message: str, bearer_token: str, u
                             try:
                                 from utils.mcp_tokens_utils import AUTH_SERVER_URL
                                 async def store_consent_request():
-                                    async with httpx.AsyncClient() as client:
+                                    async with httpx.AsyncClient(verify=False) as client:
                                         await client.post(
                                             f'{AUTH_SERVER_URL}/api/consent-requests',
                                             json={
@@ -299,7 +299,7 @@ def stream_agent_response_with_auth_detection(message: str, bearer_token: str, u
                             while user_approved is None and timeout_count < 120:  # 60 second timeout
                                 try:
                                     async def check_consent_response():
-                                        async with httpx.AsyncClient() as client:
+                                        async with httpx.AsyncClient(verify=False) as client:
                                             response = await client.get(
                                                 f'{AUTH_SERVER_URL}/api/consent-requests/{consent_id}',
                                                 timeout=5.0
@@ -346,7 +346,7 @@ def stream_agent_response_with_auth_detection(message: str, bearer_token: str, u
                             try:
                                 import httpx
                                 async def update_cookie():
-                                    async with httpx.AsyncClient() as client:
+                                    async with httpx.AsyncClient(verify=False) as client:
                                         await client.post(
                                             'http://localhost:5001/api/update-mcp-token-cookie',
                                             json={
@@ -512,7 +512,7 @@ def stream_agent_response_with_auth_detection(message: str, bearer_token: str, u
                         try:
                             from utils.mcp_tokens_utils import AUTH_SERVER_URL
                             async def store_consent_request():
-                                async with httpx.AsyncClient() as client:
+                                async with httpx.AsyncClient(verify=False) as client:
                                     await client.post(
                                         f'{AUTH_SERVER_URL}/api/consent-requests',
                                         json={

--- a/mcp_config.toml
+++ b/mcp_config.toml
@@ -1,0 +1,40 @@
+log_level = 9
+port = "8001"
+kubeconfig = #KUBECONFIG of the cluster
+list_output = "yaml"
+read_only = false
+disable_destructive = false
+require_oauth = true
+authorization_url = "http://localhost:8002"
+jwks_url = "http://localhost:8002/.well-known/jwks.json"
+server_url = "http://localhost:8001"
+certificate_authority = # certificate authority file for self-signed certificates
+
+denied_resources = [
+    {group = "", version = "v1", kind = "ServiceAccount"},
+    {group = "", version = "v1", kind = "Secret"},
+    {group = "rbac.authorization.k8s.io", version = "v1"}
+]
+
+disabled_tools = ["configuration_view"]
+
+enabled_tools = [
+    "events_list",
+    "namespaces_list",
+    "projects_list",
+    "pods_list",
+    "pods_list_in_namespace",
+    "pods_get",
+    "pods_delete",
+    "pods_top",
+    "pods_log",
+    "pods_run",
+    "pods_exec",
+    "resources_list",
+    "resources_get",
+    "resources_create_or_update",
+    "resources_delete",
+    "helm_install",
+    "helm_list",
+    "helm_uninstall"
+]

--- a/services/auth-agent/src/auth_agent/agent_instance.py
+++ b/services/auth-agent/src/auth_agent/agent_instance.py
@@ -277,9 +277,7 @@ class AuthChatAgent(ChatAgent):
             "access denied",
             "unauthorized",
             "permission denied",
-            "forbidden",
-            "401",
-            "403"
+            "forbidden"
         ]
         
         return any(indicator in error_lower for indicator in authorization_indicators)

--- a/services/stack/run.yml
+++ b/services/stack/run.yml
@@ -48,7 +48,7 @@ tool_groups:
   - toolgroup_id: mcp::mcp-auth
     provider_id: model-context-protocol
     mcp_endpoint:
-      uri: "http://localhost:8001/sse"
+      uri: "http://localhost:8001/mcp"
 
 models:
   - model_id: gpt-4-turbo

--- a/start_demo.sh
+++ b/start_demo.sh
@@ -38,9 +38,9 @@ else
     echo "   - Secret: ${JWT_SECRET:0:20}..."
 fi
 
-# Google OAuth (optional)
-export GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
-export GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
+# OAuth Configuration
+export OIDC_CLIENT_ID=${OIDC_CLIENT_ID:-}
+export OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET:-}
 
 echo ""
 echo "📋 Configuration:"
@@ -197,7 +197,7 @@ echo "🛑 To stop: Ctrl+C or run ./stop_demo.sh"
 echo ""
 
 echo "🎯 Demo Features:"
-echo "   • Google OAuth 2.0 integration"
+echo "   • OpenID Connect (OIDC) integration"
 echo "   • Database-backed user and permission management"
 echo "   • JWT token generation and validation"
 echo "   • MCP tool integration with scope-based authorization"


### PR DESCRIPTION
This PR is based on this https://github.com/gallettilance/agentic-auth/pull/3. First commit is cherry-picked from there.

Second commit provides a conceptual mechanism that works with the overall demo architecture.

Third commit is for the cases where Keycloak is configured to use self-signed certificates. So that this commit is not mandatory.

Fourth commit is simply to use `/mcp` endpoint instead of deprecated `/sse` endpoint.

Based on my tests, MCP server successfully gets a request with Authorization header including the bearer token. Consequently, MCP Server returns 200 HTTP status. However, llamastack gets generation cancelled errors but I believe that it is independent from MCP Server integration.